### PR TITLE
Copy screenshot url by default

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -50,6 +50,9 @@ const NotificationService = new Lang.Class({
 
     notification.update(_("Upload Complete"), url);
 
+  // Auto
+    Clipboard.set(url);
+    
     notification.addAction(_("Copy Link"), function () {
       Clipboard.set(url);
     });


### PR DESCRIPTION
Solution for "Copy Link" button inside the notification is not displayed anymore.
Copy screenshot url by default: Normally, when I take a screenshot, I want to copy it.
https://github.com/OttoAllmendinger/gnome-shell-imgur/issues/33